### PR TITLE
Update readme and add default information for NIU projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Please enter full details of how to reproduce this bug.
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Log file**
+Please attach the log file if relevant.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Computer used (please complete the following information):**
+
+- OS: [e.g. Linux, Windows, macOS] For macOS, please specify if you have an Intel or M1 CPU (M1 is likely if your mac is new).
+- Version [e.g. 18.04]
+- Hardware specs [e.g. 128 GB RAM, Xeon 4114 CPU].
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is. If possible, please submit a [Minimal Reproducible Example](https://en.wikipedia.org/wiki/Minimal_reproducible_example).
 
 **To Reproduce**
 Please enter full details of how to reproduce this bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]"
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).
+
+## Description
+
+**What is this PR**
+
+- [ ] Bug fix
+- [ ] Addition of a new feature
+- [ ] Other
+
+**Why is this PR needed?**
+
+**What does this PR do?**
+
+## References
+
+Please reference any existing issues/PRs that relate to this PR.
+
+## How has this PR been tested?
+
+Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.
+
+## Is this a breaking change?
+
+If this PR breaks any existing functionality, please explain how and why.
+
+## Does this PR require an update to the documentation?
+
+If any features have changed, or have been added. Please explain how the
+documentation has been updated.
+
+## Checklist:
+
+- [ ] The code has been tested locally
+- [ ] Tests have been added to cover all new functionality
+- [ ] The documentation has been updated to reflect any changes
+- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,83 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Sphinx documentation
+docs/_build/
+
+# MkDocs documentation
+/site/
+
+# PyBuilder
+target/
+
+# Pycharm and VSCode
+.idea/
+venv/
+.vscode/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# OS
+.DS_Store
+
+# written by setuptools_scm
+**/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+default_language_version:
+  node: 16.14.2
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.2
+    hooks:
+      - id: prettier
+        files: \.(js|ts|jsx|tsx|css|less|html|json|markdown|md|yaml|yml)$

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+code@adamltyson.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 **Contributors to NIU projects are absolutely encouraged**, whether to fix a
-bug, develop a new feature, or add to the documentation
+bug, develop a new feature, or add to the documentation.
 
 If you're unsure where to start, create an issue on the relevant repository. If
 for any reason, you'd rather not reach out in public, feel free to
@@ -29,7 +29,7 @@ and then run
 pip install -e .[dev]
 ```
 
-Or if using `zsh`:
+Or if using `zsh` (the default on new Apple machines):
 
 ```sh
 pip install -e '.[dev]'
@@ -50,12 +50,11 @@ to the following conventions:
 - Unless someone approves the PR with optional comments, the PR is immediately merged by the approving reviewer.
 - Please merge via "Squash and Merge" on GitHub to maintain a clean commit history.
 - Ask for a review from someone specific if you think they would be a particularly suited reviewer (possibly noting
-  why they are suited on the PR description)
+  why they are suited on the PR description).
 
 ### Formatting and QC
 
-- We use [Black](https://black.readthedocs.io/en/stable/), [ruff]
-  (https://beta.ruff.rs/docs/), and [mypy](https://mypy.readthedocs.io/en/stable/) to ensure a consistent
+- We use [Black](https://black.readthedocs.io/en/stable/), [ruff](https://beta.ruff.rs/docs/), and [mypy](https://mypy.readthedocs.io/en/stable/) to ensure a consistent
   code style.
 - The above tools are automated in the using [pre-commit](https://pre-commit.com/). Running `pre-commit install` once locally will set up the pre-commit hooks to be executed automatically before each commit.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to Neuroinformatics Unit (NIU) projects
+
+## Introduction
+
+**Contributors to NIU projects are absolutely encouraged**, whether to fix a
+bug, develop a new feature, or add to the documentation
+
+If you're unsure where to start, create an issue on the relevant repository. If
+for any reason, you'd rather not reach out in public, feel free to
+[email](mailto:code@adamltyson.com?subject=NIU-contribution) [Adam Tyson](https://github.com/adamltyson).
+
+## To contribute code
+
+### Creating a development environment
+
+It is recommended to use `conda` to install a development environment. Once you have `conda` installed, the following commands
+will create and activate a `conda` environment with the requirements needed
+for a development environment:
+
+```sh
+conda create -n NIU-dev -c conda-forge python=3.10
+conda activate NIU-dev
+```
+
+To install a specific project for development, clone the GitHub repository,
+and then run
+
+```sh
+pip install -e .[dev]
+```
+
+Or if using `zsh`:
+
+```sh
+pip install -e '.[dev]'
+```
+
+from inside the repository. This will install the package, its dependencies,
+and its development dependencies.
+
+### Pull requests
+
+In all cases, please submit code to the main repository via a pull request. The developers recommend, and adhere,
+to the following conventions:
+
+- Please submit _draft_ pull requests as early as possible (you can still push to the branch once submitted) to
+  allow for discussion.
+- One approval of a PR (by a core developer) is enough for it to be
+  merged.
+- Unless someone approves the PR with optional comments, the PR is immediately merged by the approving reviewer.
+- Please merge via "Squash and Merge" on GitHub to maintain a clean commit history.
+- Ask for a review from someone specific if you think they would be a particularly suited reviewer (possibly noting
+  why they are suited on the PR description)
+
+### Formatting and QC
+
+- We use [Black](https://black.readthedocs.io/en/stable/), [ruff]
+  (https://beta.ruff.rs/docs/), and [mypy](https://mypy.readthedocs.io/en/stable/) to ensure a consistent
+  code style.
+- The above tools are automated in the using [pre-commit](https://pre-commit.com/). Running `pre-commit install` once locally will set up the pre-commit hooks to be executed automatically before each commit.
+
+### Dependency support
+
+Packages have to choose which versions of dependencies they officially support, with minimum supported versions of each dependency used in continuous integration testing. All NIU projects follow [NEP 29 — Recommend Python and NumPy version support as a community policy standard](https://numpy.org/neps/nep-0029-deprecation_policy.html) to determine the **minimum** set of supported package versions:
+
+- The last 42 months of Python releases
+- The last 24 months of NumPy releases
+
+### Documentation
+
+- We use [Sphinx](https://www.sphinx-doc.org/en/master/) to generate documentation for Python projects.
+- Docstrings should be written in [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) format.
+
+### Logging
+
+All Python software should use the inbuilt Python logging module, rather
+than e.g. print statements.
+
+### Configuration files
+
+User-editable configuration files should use the YAML format. As far as possible, machine readable outputs from software should also use this format.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 University College London
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # .github
 
-This repo hosts information that is common to many (or all) 
+This repo hosts information that is common to many (or all)
 Neuroinformatics Unit projects, such as contributing guidelines.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # .github
+
+This repo hosts information that is common to many (or all) 
+Neuroinformatics Unit projects, such as contributing guidelines.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 # Neuroinformatics Unit
 
-The [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/) is a 
+The [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/) is a
 [Research Software Engineering]
-(https://society-rse.org/) team based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit). 
+(https://society-rse.org/) team based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit).
 
 The NIU is dedicated to the development of high quality, accurate, robust, easy to use and maintainable open-source software for neuroscience and machine learning. We collaborate with researchers and other software engineers to advance research in the two research centres and make new algorithms and tools available to the global community.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,6 @@
 # Neuroinformatics Unit
 
 The [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/) is a
-[Research Software Engineering]
-(https://society-rse.org/) team based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit).
+[Research Software Engineering](https://society-rse.org/) team based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit).
 
 The NIU is dedicated to the development of high quality, accurate, robust, easy to use and maintainable open-source software for neuroscience and machine learning. We collaborate with researchers and other software engineers to advance research in the two research centres and make new algorithms and tools available to the global community.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,7 @@
 # Neuroinformatics Unit
 
-The Neuroinformatics Unit (NIU) is a [Research Software Engineering](https://society-rse.org/) team based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit). 
+The [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/) is a 
+[Research Software Engineering]
+(https://society-rse.org/) team based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/) and the [Gatsby Computational Neuroscience Unit](https://www.ucl.ac.uk/gatsby/gatsby-computational-neuroscience-unit). 
 
 The NIU is dedicated to the development of high quality, accurate, robust, easy to use and maintainable open-source software for neuroscience and machine learning. We collaborate with researchers and other software engineers to advance research in the two research centres and make new algorithms and tools available to the global community.


### PR DESCRIPTION
I've added a number of documents and templates (based on the [BrainGlobe version](https://raw.githubusercontent.com/brainglobe/.github)). Many of these will show up on every NIU repo (unless overridden), so it would be great to get some kind of consensus, and also to keep these updated.

I've added:
* Contributing guide
* Issue templates
* PR template
* Code of conduct

I've also added a pre-commit config, a license, a gitignore, and updated the readme's. 


This PR resolves #2. 