### PR TITLE
Remove titles from labels.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: 
+title:
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
+title: 
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Feature]"
+title: 
 labels: enhancement
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: 
+title:
 labels: enhancement
 ---
 


### PR DESCRIPTION
Here is a suggestion to remove the automatic "[BUG]" and "[Feature]" from the title of issues when created by the template. Because we add the label, this information in the title is redundant. Because we only have two templates and the majority are usually feature requests, this results in a lot of redundant / repetitive [Feature] tags in the issue titles (e.g. [datashuttle](https://github.com/neuroinformatics-unit/datashuttle/issues)). 

However, maybe there are things I did not consider and also it is not very had to remove these manually if you don't like them.

Have requested review from team as will effect everyones repos.